### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/ArchivosPrueba/script.js
+++ b/ArchivosPrueba/script.js
@@ -13,14 +13,24 @@ form.addEventListener('submit', (e) => {
   if (title && description && category) {
     
     const projectItem = document.createElement('li');
-    projectItem.innerHTML = `
-      <strong>${title}</strong> (${category})
-      <p>${description}</p>
-      <button class="delete-btn">Eliminar</button>
-    `;
     
-  
-    projectItem.querySelector('.delete-btn').addEventListener('click', () => {
+    const titleElement = document.createElement('strong');
+    titleElement.textContent = title;
+    projectItem.appendChild(titleElement);
+    
+    const categoryText = document.createTextNode(` (${category})`);
+    projectItem.appendChild(categoryText);
+    
+    const descriptionElement = document.createElement('p');
+    descriptionElement.textContent = description;
+    projectItem.appendChild(descriptionElement);
+    
+    const deleteButton = document.createElement('button');
+    deleteButton.textContent = 'Eliminar';
+    deleteButton.className = 'delete-btn';
+    projectItem.appendChild(deleteButton);
+    
+    deleteButton.addEventListener('click', () => {
       projectItem.remove();
     });
     


### PR DESCRIPTION
Potential fix for [https://github.com/jhonfy3320/C-GitGitHubENAFY/security/code-scanning/1](https://github.com/jhonfy3320/C-GitGitHubENAFY/security/code-scanning/1)

To fix the issue, we should avoid using `innerHTML` to insert user-provided data into the DOM. Instead, we can use `textContent` or `createTextNode` to safely insert text, ensuring that any HTML meta-characters in the user input are escaped. This approach prevents the browser from interpreting the input as HTML.

Specifically:
1. Replace the use of `innerHTML` with DOM manipulation methods that safely handle text.
2. Create and append individual DOM elements (`<strong>`, `<p>`, `<button>`) for each part of the project item, setting their `textContent` properties to the user-provided values.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
